### PR TITLE
Making custome sort parsers error resistent

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "bootstrap": "3.1.0",
     "flat-ui": "2.1.3",
     "behavior": "https://github.com/anutron/behavior.git#v1.5.9",
-    "high-stock": "https://github.com/Behavior-UI/highstock-release.git#v2.0.4a"
+    "high-stock": "https://github.com/Behavior-UI/highstock-release.git#v2.1.10a"
   },
   "main": [
     "./dist/js/behavior-ui.js",


### PR DESCRIPTION
Issue is when you basically tell the sorter to use string or number but the DOM doesn't actually have a value. It's an error state, i.e. you shouldn't build your DOM that way to use this properly, but I didn't want it to just flat-out fail. When it does, it hides all the rows in the table (because it breaks during the sort when they are popped out of the DOM).