### PR TITLE
Rolling high stock forward from v2.0.4a to v2.1.10

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "bootstrap": "3.1.0",
     "flat-ui": "2.1.3",
     "behavior": "https://github.com/anutron/behavior.git#v1.5.9",
-    "high-stock": "https://github.com/Behavior-UI/highstock-release.git#v2.0.4a"
+    "high-stock": "https://github.com/Behavior-UI/highstock-release.git#v2.1.10a"
   },
   "main": [
     "./dist/js/behavior-ui.js",


### PR DESCRIPTION
Fixes “suck” tooltip crosshair when there are null stacked values
(amongst many other things released by high charts I’m sure)